### PR TITLE
Add DPIAware to the Manifest so this works with scaling on Windows 7+

### DIFF
--- a/VCProject/MEMZ/MEMZ.vcxproj
+++ b/VCProject/MEMZ/MEMZ.vcxproj
@@ -123,6 +123,9 @@
       <AdditionalManifestDependencies>
       </AdditionalManifestDependencies>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>dpiaware.xml</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -149,6 +152,9 @@
     <ClInclude Include="data.h" />
     <ClInclude Include="memz.h" />
     <ClInclude Include="payloads.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Xml Include="dpiaware.xml" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/VCProject/MEMZ/MEMZ.vcxproj.filters
+++ b/VCProject/MEMZ/MEMZ.vcxproj.filters
@@ -42,4 +42,9 @@
       <Filter>Headerdateien</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <Xml Include="dpiaware.xml">
+      <Filter>Ressourcendateien</Filter>
+    </Xml>
+  </ItemGroup>
 </Project>

--- a/VCProject/MEMZ/dpiaware.xml
+++ b/VCProject/MEMZ/dpiaware.xml
@@ -1,0 +1,7 @@
+﻿<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <dpiAware>true</dpiAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
This patch adds the DPIAware flag to the Manifest, which fixes the issue on Windows 7+ when scaling is enabled. On scaling-enabled systems, the visual effects only occur in some portion of the top left corner, with this fix, they are now fullscreen again.